### PR TITLE
refactor: bind lecture enrollment routes under /lectures with backward compatibility

### DIFF
--- a/src/routes/svc/v1/enrollments.route.ts
+++ b/src/routes/svc/v1/enrollments.route.ts
@@ -3,14 +3,12 @@ import { container } from '../../../config/container.config.js';
 import { validate } from '../../../middlewares/validate.middleware.js';
 import {
   enrollmentIdParamSchema,
-  lectureEnrollmentIdParamSchema,
   getSvcEnrollmentsQuerySchema,
 } from '../../../validations/enrollments.validation.js';
 
 export const svcEnrollmentsRouter = Router();
 
-const { requireAuth, requireStudent, enrollmentsController, gradesController } =
-  container;
+const { requireAuth, requireStudent, enrollmentsController } = container;
 
 /** ---------- 로그인한 사용자 ---------- */
 svcEnrollmentsRouter.use(requireAuth);
@@ -28,18 +26,4 @@ svcEnrollmentsRouter.get(
   '/:enrollmentId',
   validate(enrollmentIdParamSchema, 'params'),
   enrollmentsController.getEnrollmentLectures,
-);
-
-/** 수강 강의 상세 조회 (기존 로직 유지용) */
-svcEnrollmentsRouter.get(
-  '/lectures/:lectureEnrollmentId',
-  validate(lectureEnrollmentIdParamSchema, 'params'),
-  enrollmentsController.getEnrollment,
-);
-
-/** 수강별 성적 목록 조회 (기존 로직 유지용) */
-svcEnrollmentsRouter.get(
-  '/lectures/:lectureEnrollmentId/grades',
-  validate(lectureEnrollmentIdParamSchema, 'params'),
-  gradesController.getGradesByEnrollment,
 );

--- a/src/routes/svc/v1/index.ts
+++ b/src/routes/svc/v1/index.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { svcAuthRouter } from './auth.routes.js';
 import { svcEnrollmentsRouter } from './enrollments.route.js';
 import { svcChildrenRouter } from './children.route.js';
+import { svcLecturesRouter } from './lectures.route.js';
 import { svcGradesRouter } from './grades.route.js';
 import { svcClinicsRouter } from './clinics.route.js';
 import { svcMaterialsRouter } from './materials.route.js';
@@ -15,8 +16,12 @@ export const svcV1Router = Router();
 /** 인증 라우트 */
 svcV1Router.use('/auth', svcAuthRouter);
 
-/** 학생/학부모 강사-수강 목록 라우트 */
+/** 학생 강사-수강 목록 라우트 */
 svcV1Router.use('/enrollments', svcEnrollmentsRouter);
+
+/** 학생 강의별 수강 라우트 (하위 호환성 유지) */
+svcV1Router.use('/lectures', svcLecturesRouter);
+svcV1Router.use('/enrollments/lectures', svcLecturesRouter);
 
 /** 학부모/자녀 라우트 */
 svcV1Router.use('/children', svcChildrenRouter);

--- a/src/routes/svc/v1/lectures.route.ts
+++ b/src/routes/svc/v1/lectures.route.ts
@@ -1,0 +1,26 @@
+import { Router } from 'express';
+import { container } from '../../../config/container.config.js';
+import { validate } from '../../../middlewares/validate.middleware.js';
+import { lectureEnrollmentIdParamSchema } from '../../../validations/enrollments.validation.js';
+
+export const svcLecturesRouter = Router();
+
+const { requireAuth, requireStudent, enrollmentsController, gradesController } =
+  container;
+
+svcLecturesRouter.use(requireAuth);
+svcLecturesRouter.use(requireStudent);
+
+/** 수강 강의 상세 조회 */
+svcLecturesRouter.get(
+  '/:lectureEnrollmentId',
+  validate(lectureEnrollmentIdParamSchema, 'params'),
+  enrollmentsController.getEnrollment,
+);
+
+/** 수강별 성적 목록 조회 */
+svcLecturesRouter.get(
+  '/:lectureEnrollmentId/grades',
+  validate(lectureEnrollmentIdParamSchema, 'params'),
+  gradesController.getGradesByEnrollment,
+);


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #139

## ✨ 변경 사항

이번 PR에서 변경된 내용을 간단히 설명해주세요.

- API 주소를 문서와 통일

## 🧪 테스트 방법

리뷰어가 어떻게 테스트하면 되는지 적어주세요.

- [x] 로컬에서 페이지 접속
- [x] 주요 기능 동작 확인

## 📸 스크린샷 (선택)

UI 변경이 있다면 첨부해주세요.

## ✅ 체크리스트

- [ ] CI 통과
- [x] lint / type-check 통과
- [x] 관련 이슈와 연결됨
- [x] 불필요한 코드 제거


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized lecture-related routes for improved API structure. Endpoints for retrieving lecture enrollment details and associated grades are now accessible through dedicated routing paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->