### PR TITLE
feat: 카카오 메모 API 라우트 정리 및 프런트 규격 정합화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,10 @@ SMTP_FROM=""
 # LOG_LAMBDA_API_KEY=""
 # MONITOR_LAMBDA_URL=""
 # INTERNAL_INGEST_SECRET=""
+
+# 카카오 나에게 보내기 (개발용)
+# developers.kakao.com > 내 애플리케이션 > 앱 키 > REST API 키
+KAKAO_REST_API_KEY=""
+# 카카오 로그인 > Redirect URI (카카오 콘솔에 등록한 값과 일치해야 함)
+KAKAO_REDIRECT_URI="http://localhost:포트/api/kakao/callback"
+KAKAO_CLIENT_SECRET=

--- a/src/config/env.config.ts
+++ b/src/config/env.config.ts
@@ -44,6 +44,9 @@ const envSchema = z.object({
   SMTP_PASS: z.string().optional(),
   SMTP_FROM: z.string().optional(),
   SMTP_SECURE: z.coerce.boolean().optional(),
+  KAKAO_REST_API_KEY: z.string().optional(),
+  KAKAO_REDIRECT_URI: z.string().optional(),
+  KAKAO_CLIENT_SECRET: z.string().optional(),
 });
 
 const parseEnvironment = () => {
@@ -79,6 +82,9 @@ const parseEnvironment = () => {
       SMTP_PASS: process.env.SMTP_PASS,
       SMTP_FROM: process.env.SMTP_FROM,
       SMTP_SECURE: process.env.SMTP_SECURE,
+      KAKAO_REST_API_KEY: process.env.KAKAO_REST_API_KEY,
+      KAKAO_REDIRECT_URI: process.env.KAKAO_REDIRECT_URI,
+      KAKAO_CLIENT_SECRET: process.env.KAKAO_CLIENT_SECRET,
     });
   } catch (err) {
     if (err instanceof z.ZodError) {

--- a/src/controllers/kakao.controller.ts
+++ b/src/controllers/kakao.controller.ts
@@ -1,0 +1,91 @@
+import { Request, Response, NextFunction } from 'express';
+import {
+  getKakaoAccessToken,
+  saveKakaoToken,
+  sendKakaoMemo,
+} from '../services/kakao.service.js';
+import { config } from '../config/env.config.js';
+import { successResponse } from '../utils/response.util.js';
+
+export class KakaoController {
+  /** 카카오 로그인 URL 리다이렉트 */
+  redirectToKakaoAuth = (_req: Request, res: Response) => {
+    if (!config.KAKAO_REST_API_KEY || !config.KAKAO_REDIRECT_URI) {
+      res.status(500).json({ message: '카카오 설정이 누락되었습니다.' });
+      return;
+    }
+
+    const authUrl =
+      'https://kauth.kakao.com/oauth/authorize' +
+      `?client_id=${config.KAKAO_REST_API_KEY}` +
+      `&redirect_uri=${encodeURIComponent(config.KAKAO_REDIRECT_URI)}` +
+      '&response_type=code' +
+      '&scope=talk_message';
+
+    res.redirect(authUrl);
+  };
+
+  /** 인가 코드 수신 → 토큰 저장 */
+  handleKakaoCallback = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => {
+    try {
+      const { code } = req.query as { code?: string };
+      if (!code) {
+        res.status(400).json({ message: '인가 코드가 없습니다.' });
+        return;
+      }
+
+      const tokenData = await getKakaoAccessToken(code);
+      await saveKakaoToken(
+        tokenData.access_token,
+        tokenData.refresh_token ?? '',
+      );
+
+      return successResponse(res, {
+        data: { message: '카카오 토큰 저장 완료' },
+        message: '카카오 로그인 성공. 이제 나에게 보내기를 사용할 수 있습니다.',
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  /** 나에게 보내기 */
+  sendMemo = async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { title, description, imageUrl, webUrl, buttonTitle } =
+        req.body as {
+          title: string;
+          description: string;
+          imageUrl?: string;
+          webUrl: string;
+          buttonTitle?: string;
+        };
+
+      if (!title || !description || !webUrl) {
+        res
+          .status(400)
+          .json({ message: 'title, description, webUrl은 필수입니다.' });
+        return;
+      }
+
+      await sendKakaoMemo({
+        title,
+        description,
+        imageUrl,
+        webUrl,
+        buttonTitle,
+      });
+
+      return successResponse(res, {
+        data: { sent: true },
+        message: '카카오톡 나에게 보내기 완료.',
+      });
+    } catch (error) {
+      next(error);
+    }
+  };
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,6 +2,7 @@ import express from 'express';
 import { mgmtV1Router } from './mgmt/v1/index.js';
 import { svcV1Router } from './svc/v1/index.js';
 import { publicV1Router } from './public/v1/index.js';
+import { kakaoRouter } from './kakao.route.js';
 
 export const router = express.Router();
 
@@ -22,5 +23,7 @@ router.use('/api/svc/v1', svcV1Router);
 
 /** 공개 인증 API (통합) */
 router.use('/api/public/v1', publicV1Router);
+
+router.use('/api/kakao', kakaoRouter);
 
 export default router;

--- a/src/routes/kakao.route.ts
+++ b/src/routes/kakao.route.ts
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { KakaoController } from '../controllers/kakao.controller.js';
+
+export const kakaoRouter = Router();
+const kakaoController = new KakaoController();
+
+/** GET /api/kakao/auth — 카카오 로그인 URL 리다이렉트 */
+kakaoRouter.get('/auth', kakaoController.redirectToKakaoAuth);
+
+/** GET /api/kakao/callback — 인가 코드 수신 → 토큰 저장 */
+kakaoRouter.get('/callback', kakaoController.handleKakaoCallback);

--- a/src/routes/mgmt/v1/index.ts
+++ b/src/routes/mgmt/v1/index.ts
@@ -90,3 +90,6 @@ mgmtV1Router.use('/grades', mgmtGradesRouter);
 /** 프로필 라우트 */
 import { mgmtProfileRouter } from './profile.route.js';
 mgmtV1Router.use('/me', mgmtProfileRouter);
+
+import { mgmtKakaoRouter } from './kakao.route.js';
+mgmtV1Router.use('/kakao', mgmtKakaoRouter);

--- a/src/routes/mgmt/v1/kakao.route.ts
+++ b/src/routes/mgmt/v1/kakao.route.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { container } from '../../../config/container.config.js';
+import { KakaoController } from '../../../controllers/kakao.controller.js';
+
+export const mgmtKakaoRouter = Router();
+
+const { requireAuth, requireInstructorOrAssistant } = container;
+const kakaoController = new KakaoController();
+
+mgmtKakaoRouter.use(requireAuth);
+mgmtKakaoRouter.use(requireInstructorOrAssistant);
+
+mgmtKakaoRouter.post('/memo', kakaoController.sendMemo);

--- a/src/services/kakao.service.ts
+++ b/src/services/kakao.service.ts
@@ -1,0 +1,203 @@
+import { redis } from '../config/redis.config.js';
+import { config } from '../config/env.config.js';
+
+const KAKAO_TOKEN_KEY = 'kakao:token';
+const KAKAO_TOKEN_TTL = 60 * 60 * 24 * 30; // 30일
+
+type KakaoTokenResponse = {
+  access_token: string;
+  token_type: string;
+  refresh_token?: string;
+  expires_in: number;
+  refresh_token_expires_in?: number;
+};
+
+type KakaoStoredToken = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+export type KakaoMemoPayload = {
+  title: string; // max 200자
+  description: string; // max 200자
+  imageUrl?: string; // S3 URL
+  webUrl: string;
+  buttonTitle?: string;
+};
+
+const trimByCodePoints = (value: string, maxLength: number): string =>
+  Array.from(value).slice(0, maxLength).join('');
+
+const kakaoPost = async <T>(
+  url: string,
+  params: URLSearchParams,
+  accessToken?: string,
+): Promise<T> => {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/x-www-form-urlencoded',
+  };
+  if (accessToken) {
+    headers['Authorization'] = `Bearer ${accessToken}`;
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers,
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`카카오 API 오류 [${response.status}]: ${text}`);
+  }
+
+  return response.json() as Promise<T>;
+};
+
+/** 인가 코드 → 액세스 토큰 교환 */
+export const getKakaoAccessToken = async (
+  code: string,
+): Promise<KakaoTokenResponse> => {
+  if (!config.KAKAO_REST_API_KEY || !config.KAKAO_REDIRECT_URI) {
+    throw new Error(
+      'KAKAO_REST_API_KEY 또는 KAKAO_REDIRECT_URI가 설정되지 않았습니다.',
+    );
+  }
+
+  const params = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: config.KAKAO_REST_API_KEY,
+    redirect_uri: config.KAKAO_REDIRECT_URI,
+    code,
+  });
+
+  // 클라이언트 시크릿 활성화된 경우 포함
+  if (config.KAKAO_CLIENT_SECRET) {
+    params.set('client_secret', config.KAKAO_CLIENT_SECRET);
+  }
+
+  return kakaoPost<KakaoTokenResponse>(
+    'https://kauth.kakao.com/oauth/token',
+    params,
+  );
+};
+
+/** 토큰 저장 (Redis) */
+export const saveKakaoToken = async (
+  accessToken: string,
+  refreshToken: string,
+): Promise<void> => {
+  const stored: KakaoStoredToken = { accessToken, refreshToken };
+  await redis.set(
+    KAKAO_TOKEN_KEY,
+    JSON.stringify(stored),
+    'EX',
+    KAKAO_TOKEN_TTL,
+  );
+};
+
+/** 토큰 조회 (Redis) */
+export const getKakaoToken = async (): Promise<KakaoStoredToken | null> => {
+  const raw = await redis.get(KAKAO_TOKEN_KEY);
+  if (!raw) return null;
+  return JSON.parse(raw) as KakaoStoredToken;
+};
+
+/** 액세스 토큰 갱신 */
+const refreshKakaoToken = async (refreshToken: string): Promise<string> => {
+  if (!config.KAKAO_REST_API_KEY) {
+    throw new Error('KAKAO_REST_API_KEY가 설정되지 않았습니다.');
+  }
+
+  const params = new URLSearchParams({
+    grant_type: 'refresh_token',
+    client_id: config.KAKAO_REST_API_KEY,
+    refresh_token: refreshToken,
+  });
+
+  // 클라이언트 시크릿 활성화된 경우 포함
+  if (config.KAKAO_CLIENT_SECRET) {
+    params.set('client_secret', config.KAKAO_CLIENT_SECRET);
+  }
+
+  const data = await kakaoPost<KakaoTokenResponse>(
+    'https://kauth.kakao.com/oauth/token',
+    params,
+  );
+
+  const newRefreshToken = data.refresh_token ?? refreshToken;
+  await saveKakaoToken(data.access_token, newRefreshToken);
+
+  return data.access_token;
+};
+
+const isUnauthorizedError = (error: unknown): boolean => {
+  if (error instanceof Error) {
+    return error.message.includes('[401]');
+  }
+  return false;
+};
+
+/** 나에게 보내기 (토큰 만료 시 자동 갱신) */
+export const sendKakaoMemo = async (
+  payload: KakaoMemoPayload,
+): Promise<void> => {
+  const stored = await getKakaoToken();
+  if (!stored) {
+    throw new Error(
+      '카카오 토큰이 없습니다. /api/kakao/auth 로 먼저 로그인하세요.',
+    );
+  }
+
+  const buildParams = (): URLSearchParams => {
+    const templateObject: Record<string, unknown> = {
+      object_type: 'feed',
+      content: {
+        title: trimByCodePoints(payload.title, 200),
+        description: trimByCodePoints(payload.description, 200),
+        link: {
+          web_url: payload.webUrl,
+          mobile_web_url: payload.webUrl,
+        },
+        ...(payload.imageUrl && {
+          image_url: payload.imageUrl,
+          image_width: 800,
+          image_height: 400,
+        }),
+      },
+      buttons: [
+        {
+          title: trimByCodePoints(payload.buttonTitle || '성적표 확인', 200),
+          link: {
+            web_url: payload.webUrl,
+            mobile_web_url: payload.webUrl,
+          },
+        },
+      ],
+    };
+
+    return new URLSearchParams({
+      template_object: JSON.stringify(templateObject),
+    });
+  };
+
+  try {
+    await kakaoPost(
+      'https://kapi.kakao.com/v2/api/talk/memo/default/send',
+      buildParams(),
+      stored.accessToken,
+    );
+  } catch (error) {
+    // 401 (토큰 만료) 시 자동 갱신 후 재시도
+    if (isUnauthorizedError(error)) {
+      const newAccessToken = await refreshKakaoToken(stored.refreshToken);
+      await kakaoPost(
+        'https://kapi.kakao.com/v2/api/talk/memo/default/send',
+        buildParams(),
+        newAccessToken,
+      );
+    } else {
+      throw error;
+    }
+  }
+};


### PR DESCRIPTION
 🔗 관련 이슈
- Closes #이슈번호

 ✨ 변경 사항

- 카카오 OAuth 라우트 추가/정리
  - `GET /api/kakao/auth`
  - `GET /api/kakao/callback`
- 카카오 메모 전송 라우트를 mgmt 전용으로 분리
  - `POST /api/mgmt/v1/kakao/memo`
  - `requireAuth` + `requireInstructorOrAssistant` 적용
- 카카오 토큰 처리 서비스 추가
  - 인가코드 토큰 교환
  - Redis 저장/조회
  - 401 시 refresh token으로 access token 갱신 후 재시도
- 프런트 규격 정합화
  - 메시지 `description` 길이 제한을 200자로 통일
  - 유니코드 안전 절단(trim) 적용

 🧪 테스트 방법
- [ ] `.env`에 카카오 관련 환경 변수 설정 (`KAKAO_REST_API_KEY`, `KAKAO_REDIRECT_URI`, `KAKAO_CLIENT_SECRET`)
- [ ] `GET /api/kakao/auth` 호출 시 카카오 인증 페이지로 리다이렉트되는지 확인
- [ ] 인증 완료 후 callback 처리로 토큰 저장이 정상 동작하는지 확인
- [ ] `POST /api/mgmt/v1/kakao/memo` 호출 시 카카오 나에게 보내기 전송 성공 확인
- [ ] 토큰 만료 상황에서 자동 갱신 후 재시도되는지 확인

 📸 스크린샷 (선택)
- 백엔드 변경 중심 PR로 스크린샷은 생략합니다.

 ✅ 체크리스트
- [ ] CI 통과
- [x] lint / type-check 통과
- [ ] 관련 이슈와 연결됨
- [x] 불필요한 코드 제거 (중복 memo 경로 정리: `/api/kakao/memo` 제거, mgmt 전용화)
