### PR TITLE
hotfix/student phone duplicated

### DIFF
--- a/src/services/lectures.service.test.ts
+++ b/src/services/lectures.service.test.ts
@@ -1,5 +1,6 @@
 import { LecturesService } from './lectures.service.js';
 import {
+  BadRequestException,
   NotFoundException,
   ForbiddenException,
 } from '../err/http.exception.js';
@@ -371,6 +372,87 @@ describe('LecturesService - @unit #critical', () => {
         ).rejects.toThrow('강사를 찾을 수 없습니다.');
 
         expect(mockLecturesRepo.create).not.toHaveBeenCalled();
+      });
+
+      it('기존 수강생 전화번호와 요청 학생 이름이 일치하지 않으면 BadRequestException을 던진다', async () => {
+        const enrollmentRequest =
+          createLectureRequests.withEnrollments.enrollments![0];
+        const existingEnrollment = {
+          ...mockEnrollments.active,
+          studentPhone: enrollmentRequest.studentPhone,
+          studentName: '다른학생',
+          parentPhone: enrollmentRequest.parentPhone,
+        };
+
+        mockInstructorRepo.findById.mockResolvedValue({
+          ...mockInstructor,
+          ...mockInstructorWithUser,
+        });
+        mockEnrollmentsRepo.findManyByInstructorAndPhones.mockResolvedValue([
+          existingEnrollment,
+        ]);
+
+        (mockPrisma.$transaction as jest.Mock).mockImplementation(
+          async (fn) => await fn(mockPrisma),
+        );
+
+        await expect(
+          lecturesService.createLecture(mockInstructor.id, {
+            ...createLectureRequests.withEnrollments,
+            enrollments: [enrollmentRequest],
+            startAt: new Date(createLectureRequests.withEnrollments.startAt),
+            endAt: new Date(createLectureRequests.withEnrollments.endAt),
+          }),
+        ).rejects.toThrow(BadRequestException);
+
+        await expect(
+          lecturesService.createLecture(mockInstructor.id, {
+            ...createLectureRequests.withEnrollments,
+            enrollments: [enrollmentRequest],
+            startAt: new Date(createLectureRequests.withEnrollments.startAt),
+            endAt: new Date(createLectureRequests.withEnrollments.endAt),
+          }),
+        ).rejects.toThrow(
+          '이미 등록된 학생 전화번호와 학생 정보가 일치하지 않습니다.',
+        );
+
+        expect(mockLecturesRepo.create).not.toHaveBeenCalled();
+        expect(mockLectureEnrollmentsRepo.createMany).not.toHaveBeenCalled();
+      });
+
+      it('기존 수강생 전화번호와 요청 학부모 전화번호가 일치하지 않으면 BadRequestException을 던진다', async () => {
+        const enrollmentRequest =
+          createLectureRequests.withEnrollments.enrollments![0];
+        const existingEnrollment = {
+          ...mockEnrollments.active,
+          studentPhone: enrollmentRequest.studentPhone,
+          studentName: enrollmentRequest.studentName,
+          parentPhone: '010-0000-0000',
+        };
+
+        mockInstructorRepo.findById.mockResolvedValue({
+          ...mockInstructor,
+          ...mockInstructorWithUser,
+        });
+        mockEnrollmentsRepo.findManyByInstructorAndPhones.mockResolvedValue([
+          existingEnrollment,
+        ]);
+
+        (mockPrisma.$transaction as jest.Mock).mockImplementation(
+          async (fn) => await fn(mockPrisma),
+        );
+
+        await expect(
+          lecturesService.createLecture(mockInstructor.id, {
+            ...createLectureRequests.withEnrollments,
+            enrollments: [enrollmentRequest],
+            startAt: new Date(createLectureRequests.withEnrollments.startAt),
+            endAt: new Date(createLectureRequests.withEnrollments.endAt),
+          }),
+        ).rejects.toThrow(BadRequestException);
+
+        expect(mockLecturesRepo.create).not.toHaveBeenCalled();
+        expect(mockLectureEnrollmentsRepo.createMany).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/services/lectures.service.ts
+++ b/src/services/lectures.service.ts
@@ -1,6 +1,9 @@
 import { PrismaClient } from '../generated/prisma/client.js';
 import { EnrollmentStatus } from '../constants/enrollments.constant.js';
-import { NotFoundException } from '../err/http.exception.js';
+import {
+  BadRequestException,
+  NotFoundException,
+} from '../err/http.exception.js';
 import {
   LecturesRepository,
   LectureWithTimes,
@@ -115,15 +118,54 @@ export class LecturesService {
     if (!instructor) throw new NotFoundException('강사를 찾을 수 없습니다.');
 
     return await this.prisma.$transaction(async (tx) => {
-      // 1. 강의 생성
+      const enrollmentRequests = data.enrollments ?? [];
+      const existingPhoneMap = new Map<
+        string,
+        Awaited<
+          ReturnType<EnrollmentsRepository['findManyByInstructorAndPhones']>
+        >[number]
+      >();
+
+      if (enrollmentRequests.length > 0) {
+        // 1. 요청된 학생들의 전화번호 목록 추출
+        const studentPhones = enrollmentRequests.map((e) => e.studentPhone);
+
+        // 2. 기존 Enrollment 조회 (해당 강사의 학생 명단에서)
+        const existingEnrollments =
+          await this.enrollmentsRepository.findManyByInstructorAndPhones(
+            instructorId,
+            studentPhones,
+            tx,
+          );
+
+        for (const existing of existingEnrollments) {
+          existingPhoneMap.set(existing.studentPhone, existing);
+        }
+
+        for (const enrollmentReq of enrollmentRequests) {
+          const existing = existingPhoneMap.get(enrollmentReq.studentPhone);
+          if (!existing) continue;
+
+          if (
+            existing.studentName !== enrollmentReq.studentName ||
+            existing.parentPhone !== enrollmentReq.parentPhone
+          ) {
+            throw new BadRequestException(
+              '이미 등록된 학생 전화번호와 학생 정보가 일치하지 않습니다.',
+            );
+          }
+        }
+      }
+
+      // 3. 강의 생성
       const lecture = await this.lecturesRepository.create(
         { ...data, instructorId },
         tx,
       );
 
-      // 2. 수강생 처리 (있는 경우)
+      // 4. 수강생 처리 (있는 경우)
       let lectureEnrollments: LectureEnrollment[] = [];
-      if (data.enrollments && data.enrollments.length > 0) {
+      if (enrollmentRequests.length > 0) {
         const resolveStudentId = async (
           enrollmentReq: LectureEnrollmentRequest,
         ) => {
@@ -148,28 +190,13 @@ export class LecturesService {
           return link?.id;
         };
 
-        // 2-1. 요청된 학생들의 전화번호 목록 추출
-        const studentPhones = data.enrollments.map((e) => e.studentPhone);
-
-        // 2-2. 기존 Enrollment 조회 (해당 강사의 학생 명단에서)
-        const existingEnrollments =
-          await this.enrollmentsRepository.findManyByInstructorAndPhones(
-            instructorId,
-            studentPhones,
-            tx,
-          );
-
-        const existingPhoneMap = new Map(
-          existingEnrollments.map((e) => [e.studentPhone, e]),
-        );
-
-        // 2-3. 새롭게 생성해야 할 Enrollment와 재사용할 Enrollment 분류
+        // 4-1. 새롭게 생성해야 할 Enrollment와 재사용할 Enrollment 분류
         const newEnrollmentsData: Prisma.EnrollmentUncheckedCreateInput[] = [];
         const pendingLectureEnrollments: Prisma.LectureEnrollmentUncheckedCreateInput[] =
           [];
         const pendingNewLectureEnrollments: LectureEnrollmentRequest[] = [];
 
-        for (const enrollmentReq of data.enrollments) {
+        for (const enrollmentReq of enrollmentRequests) {
           const existing = existingPhoneMap.get(enrollmentReq.studentPhone);
           if (existing) {
             const connectionData: Prisma.EnrollmentUpdateInput = {};
@@ -230,7 +257,7 @@ export class LecturesService {
           }
         }
 
-        // 2-4. 새 Enrollment 일괄 생성
+        // 4-2. 새 Enrollment 일괄 생성
         if (newEnrollmentsData.length > 0) {
           const createdEnrollments =
             await this.enrollmentsRepository.createMany(newEnrollmentsData, tx);
@@ -256,7 +283,7 @@ export class LecturesService {
           );
         }
 
-        // 2-5. LectureEnrollment 생성 (강의와 학생 연결)
+        // 4-3. LectureEnrollment 생성 (강의와 학생 연결)
         lectureEnrollments = await this.lectureEnrollmentsRepository.createMany(
           pendingLectureEnrollments,
           tx,

--- a/src/validations/lectures.validation.test.ts
+++ b/src/validations/lectures.validation.test.ts
@@ -25,5 +25,39 @@ describe('lectures.validation', () => {
         );
       }
     });
+
+    it('중첩 enrollments에 같은 학생 전화번호가 중복되면 실패해야 한다', () => {
+      const result = createLectureSchema.safeParse({
+        title: '테스트 강의',
+        enrollments: [
+          {
+            school: '테스트고',
+            schoolYear: '고1',
+            studentName: '홍길동',
+            studentPhone: '010-1234-5678',
+            parentPhone: '010-9876-5432',
+          },
+          {
+            school: '테스트고',
+            schoolYear: '고2',
+            studentName: '김길동',
+            studentPhone: '010-1234-5678',
+            parentPhone: '010-1111-2222',
+          },
+        ],
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              message: '중복된 학생 전화번호는 허용되지 않습니다.',
+              path: ['enrollments', 1, 'studentPhone'],
+            }),
+          ]),
+        );
+      }
+    });
   });
 });

--- a/src/validations/lectures.validation.ts
+++ b/src/validations/lectures.validation.ts
@@ -67,57 +67,78 @@ export type LectureEnrollmentDto = z.infer<typeof lectureEnrollmentSchema>;
 /**
  * 강의 생성 요청 검증 스키마
  */
-export const createLectureSchema = z.object({
-  /** 강의 제목 */
-  title: z
-    .string()
-    .min(1, { message: '강의 제목은 필수입니다.' })
-    .max(LectureLimits.TITLE_MAX_LENGTH, {
-      message: `강의 제목은 ${LectureLimits.TITLE_MAX_LENGTH}자를 초과할 수 없습니다.`,
-    })
-    .trim(),
+export const createLectureSchema = z
+  .object({
+    /** 강의 제목 */
+    title: z
+      .string()
+      .min(1, { message: '강의 제목은 필수입니다.' })
+      .max(LectureLimits.TITLE_MAX_LENGTH, {
+        message: `강의 제목은 ${LectureLimits.TITLE_MAX_LENGTH}자를 초과할 수 없습니다.`,
+      })
+      .trim(),
 
-  /** 대상 학년 */
-  schoolYear: z
-    .enum(SCHOOL_YEARS, { message: '유효한 학년이 아닙니다.' })
-    .optional(),
+    /** 대상 학년 */
+    schoolYear: z
+      .enum(SCHOOL_YEARS, { message: '유효한 학년이 아닙니다.' })
+      .optional(),
 
-  /** 과목 */
-  subject: z
-    .string()
-    .max(LectureLimits.SUBJECT_MAX_LENGTH, {
-      message: `과목명은 ${LectureLimits.SUBJECT_MAX_LENGTH}자를 초과할 수 없습니다.`,
-    })
-    .trim()
-    .optional(),
+    /** 과목 */
+    subject: z
+      .string()
+      .max(LectureLimits.SUBJECT_MAX_LENGTH, {
+        message: `과목명은 ${LectureLimits.SUBJECT_MAX_LENGTH}자를 초과할 수 없습니다.`,
+      })
+      .trim()
+      .optional(),
 
-  /** 강의 설명 */
-  description: z
-    .string()
-    .max(LectureLimits.DESCRIPTION_MAX_LENGTH, {
-      message: `설명은 ${LectureLimits.DESCRIPTION_MAX_LENGTH}자를 초과할 수 없습니다.`,
-    })
-    .trim()
-    .optional(),
+    /** 강의 설명 */
+    description: z
+      .string()
+      .max(LectureLimits.DESCRIPTION_MAX_LENGTH, {
+        message: `설명은 ${LectureLimits.DESCRIPTION_MAX_LENGTH}자를 초과할 수 없습니다.`,
+      })
+      .trim()
+      .optional(),
 
-  /** 강의 시작일 */
-  startAt: dateTimeSchema.optional().nullable(),
+    /** 강의 시작일 */
+    startAt: dateTimeSchema.optional().nullable(),
 
-  /** 강의 종료일 */
-  endAt: dateTimeSchema.optional().nullable(),
+    /** 강의 종료일 */
+    endAt: dateTimeSchema.optional().nullable(),
 
-  /** 강의 상태 (예정, 진행중, 종료) */
-  status: z
-    .nativeEnum(LectureStatus)
-    .optional()
-    .default(LectureStatus.SCHEDULED),
+    /** 강의 상태 (예정, 진행중, 종료) */
+    status: z
+      .nativeEnum(LectureStatus)
+      .optional()
+      .default(LectureStatus.SCHEDULED),
 
-  /** 수업 시간 목록 */
-  lectureTimes: z.array(lectureTimeItemSchema).optional(),
+    /** 수업 시간 목록 */
+    lectureTimes: z.array(lectureTimeItemSchema).optional(),
 
-  /** 수강 등록 목록 (강의 생성 시 동시 등록용) */
-  enrollments: z.array(lectureEnrollmentSchema).optional(),
-});
+    /** 수강 등록 목록 (강의 생성 시 동시 등록용) */
+    enrollments: z.array(lectureEnrollmentSchema).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.enrollments) return;
+
+    const seenStudentPhoneIndexes = new Map<string, number>();
+
+    data.enrollments.forEach((enrollment, index) => {
+      const firstIndex = seenStudentPhoneIndexes.get(enrollment.studentPhone);
+
+      if (firstIndex !== undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: '중복된 학생 전화번호는 허용되지 않습니다.',
+          path: ['enrollments', index, 'studentPhone'],
+        });
+        return;
+      }
+
+      seenStudentPhoneIndexes.set(enrollment.studentPhone, index);
+    });
+  });
 
 /** 강의 생성 DTO 타입 */
 export type CreateLectureDto = z.infer<typeof createLectureSchema>;


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #이슈번호

## ✨ 변경 사항

이번 PR에서 변경된 내용을 간단히 설명해주세요.

- 수업 개설 시 학생 정보를 입력할 때, 두 명 이상의 학생에 같은 전화번호가 입력되어있으면 Prisma 에러가 발생했습니다. 이부분에 대해 에러처리를 유효성 검사에서 하도록 변경하였습니다. 
- 추가로 이미 등록된 기존 학생의 전화번호와 같은 번호를 수업 개설 시 등록 할 때 기존 정보와 불일치 시 덮어씌워질 수 있는 문제도 에러처리로 빼두었습니다.

## 🧪 테스트 방법

리뷰어가 어떻게 테스트하면 되는지 적어주세요.

- [x] 로컬에서 페이지 접속
- [x] 주요 기능 동작 확인

## 📸 스크린샷 (선택)

UI 변경이 있다면 첨부해주세요.

## ✅ 체크리스트

- [x] CI 통과
- [x] lint / type-check 통과
- [ ] 관련 이슈와 연결됨
- [ ] 불필요한 코드 제거
